### PR TITLE
security_groups_masters_internal to external LB

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -50,7 +50,7 @@ module "dcos-lb-masters" {
   }
   cluster_name       = "${var.cluster_name}"
   subnet_ids         = ["${var.subnet_ids}"]
-  security_groups    = ["${var.security_groups_masters}"]
+  security_groups    = ["${var.security_groups_masters}", "${var.security_groups_masters_internal}"]
   instances          = ["${var.master_instances}"]
   https_acm_cert_arn = "${var.masters_acm_cert_arn}"
   internal           = "${var.internal}"


### PR DESCRIPTION
This is necessary to make the connections healthy between the ALB and the instances. Since the security_group_masters_internal variable is a requirement currently for this module, it is simple enough to just add it to the list of security groups. 