### PR TITLE
Add config options for setting Admin Router gRPC port

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ module "dcos-lbs" {
 | security\_groups\_masters\_internal | Security Group IDs to use for internal communication to masters | list | n/a | yes |
 | security\_groups\_public\_agents | Security Group IDs to use for external public agents load balancer | list | n/a | yes |
 | subnet\_ids | List of subnet IDs created in this network | list | n/a | yes |
+| adminrouter\_grpc\_proxy\_port |  | string | `"12379"` | no |
 | disable\_masters | [MASTERS] Do not create load balancer and its resources | string | `"false"` | no |
 | disable\_public\_agents | [PUBLIC AGENTS] Do not create load balancer and its resources | string | `"false"` | no |
 | internal | This ELB is internal only | string | `"false"` | no |

--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,7 @@ module "dcos-lb-masters" {
 
 module "dcos-lb-masters-internal" {
   source  = "dcos-terraform/lb-masters-internal/aws"
-  version = "~> 0.2.0"
+  version = "~> 0.2.1"
 
   providers = {
     aws = "aws"

--- a/main.tf
+++ b/main.tf
@@ -67,15 +67,16 @@ module "dcos-lb-masters-internal" {
     aws = "aws"
   }
 
-  cluster_name       = "${var.cluster_name}"
-  subnet_ids         = ["${var.subnet_ids}"]
-  security_groups    = ["${var.security_groups_masters_internal}"]
-  instances          = ["${var.master_instances}"]
-  disable            = "${var.disable_masters}"
-  https_acm_cert_arn = "${var.masters_internal_acm_cert_arn}"
-  num_instances      = "${var.num_masters}"
-  name_prefix        = "${var.name_prefix}"
-  tags               = "${var.tags}"
+  cluster_name                = "${var.cluster_name}"
+  subnet_ids                  = ["${var.subnet_ids}"]
+  security_groups             = ["${var.security_groups_masters_internal}"]
+  instances                   = ["${var.master_instances}"]
+  disable                     = "${var.disable_masters}"
+  https_acm_cert_arn          = "${var.masters_internal_acm_cert_arn}"
+  num_instances               = "${var.num_masters}"
+  name_prefix                 = "${var.name_prefix}"
+  tags                        = "${var.tags}"
+  adminrouter_grpc_proxy_port = "${var.adminrouter_grpc_proxy_port}"
 }
 
 module "dcos-lb-public-agents" {

--- a/variables.tf
+++ b/variables.tf
@@ -86,3 +86,8 @@ variable "num_masters" {
 variable "num_public_agents" {
   description = "Specify the amount of public agents. These agents will host marathon-lb and edgelb"
 }
+
+variable "adminrouter_grpc_proxy_port" {
+  description = ""
+  default     = 12379
+}


### PR DESCRIPTION
This PR adds support for Add config options for setting Admin Router gRPC port. See the Jira issue below for more details:

https://jira.d2iq.com/browse/D2IQ-62476